### PR TITLE
Revised registry process + more

### DIFF
--- a/run.bat
+++ b/run.bat
@@ -1,52 +1,76 @@
 @echo off
+:: Prompt UAC if script is not elevated
+net session >nul 2>&1
+if %errorlevel% neq 0 (
+	:: call UAC prompt
+	echo Set UAC = CreateObject^("Shell.Application"^) > "%temp%\getadmin.vbs"
+	echo UAC.ShellExecute "%~s0", "", "", "runas", 1 >> "%temp%\getadmin.vbs"
+	"%temp%\getadmin.vbs"
+	exit /b
+)
+
 :: Set variables
-set "ICON_DIR=%ProgramData%\CustomIcons"
-set "SCRIPT_DIR=%~dp0"
-set "ICONS_SOURCE=%SCRIPT_DIR%Icon"
+set "BATCH_FOLDER=%~dp0"
+set "ICONS_SOURCE=%BATCH_FOLDER%\Icons"
+set "ICONS_TARGET=%ProgramData%\IrfanView_FileIconOverrides"
 
 :: Verify the Icons folder exists
 if not exist "%ICONS_SOURCE%" (
-    echo The 'Icons' folder is missing. Place the folder in the same directory as this script.
-    pause
-    exit /b
+	echo The 'Icons' folder is missing. Create one containing .ico files then re-run the script.
+	pause
+	exit /b
 )
 
 :: Verify at least one .ico file exists in the Icons folder
 dir "%ICONS_SOURCE%\*.ico" >nul 2>&1
 if errorlevel 1 (
-    echo No .ico files found in the 'Icons' folder. Ensure it contains valid .ico files.
+    echo No '.ico' files found in the 'Icons' folder. Add at least one to the folder then re-run the script.
     pause
     exit /b
 )
 
 :: Create icon directory in ProgramData if it doesn't exist
-if not exist "%ICON_DIR%" (
-    mkdir "%ICON_DIR%"
-    echo Created directory: %ICON_DIR%
+if not exist "%ICONS_TARGET%" (
+	mkdir "%ICONS_TARGET%"
+	echo Created directory:	%ICONS_TARGET%
 )
 
 :: Copy icons to ProgramData
-xcopy /y /q "%ICONS_SOURCE%\*.ico" "%ICON_DIR%"
+xcopy /y /q "%ICONS_SOURCE%\*.ico" "%ICONS_TARGET%"
 if errorlevel 1 (
-    echo Failed to copy icons. Please check permissions and file paths.
-    pause
-    exit /b
+	echo Failed to copy icons. Check user permissions and/or access to file paths.
+	pause
+	exit /b
 )
 
 :: Register filetype icons
 echo Updating registry...
 
-:: Register .jpeg and .jpg with the custom icons
-reg add "HKEY_CLASSES_ROOT\IrfanView.jpg\DefaultIcon" /ve /d "%ICON_DIR%\jpg.ico,0" /f
-reg add "HKEY_CLASSES_ROOT\IrfanView.jpeg\DefaultIcon" /ve /d "%ICON_DIR%\jpg.ico,0" /f
-reg add "HKEY_CLASSES_ROOT\IrfanView.gif\DefaultIcon" /ve /d "%ICON_DIR%\gif.ico,0" /f
-reg add "HKEY_CLASSES_ROOT\IrfanView.png\DefaultIcon" /ve /d "%ICON_DIR%\png.ico,0" /f
-reg add "HKEY_CLASSES_ROOT\IrfanView.webp\DefaultIcon" /ve /d "%ICON_DIR%\webp.ico,0" /f
+:: Register new and existing icons
+for %%i in ("%ICONS_SOURCE%\*.ico") do (
+	reg query "HKCR\IrfanView.%%~ni" > nul
+	if %errorlevel% neq 0 (
+		:: override extension default for previously default icons
+		reg add "HKCR\.%%~ni" /ve /d "IrfanView.%%~ni" /f > nul
+
+		:: copy irfanview key and shell\open\command subkeys, same for every type
+		reg copy "HKCR\IrfanView" "HKCR\IrfanView.%%~ni" /s /f > nul
+		
+		echo ::  Successfully reated new file type association for [[ %%~ni ]]
+	)
+	
+	:: [[ personal ]] remove IrfanView prefix from explorer extension name
+	reg add "HKCR\IrfanView.%%~ni" /ve /d "%%~ni File" /f > nul
+	
+	:: override pointer from old icon to new icon
+	reg add "HKCR\IrfanView.%%~ni\DefaultIcon" /ve /d "%ICONS_TARGET%\%%~nxi,0" /f > nul
+	echo ::  Successfully set new file type icon for [[ %%~ni ]]
+)
 
 :: Refresh the icon cache
-echo Refreshing icon cache...
+echo Restarting explorer for effect
 taskkill /im explorer.exe /f >nul
 start explorer.exe
 
-echo Icons updated successfully!
+echo IrfanView file icons overridden successfully!
 pause


### PR DESCRIPTION
## Preface
Thank you for making this script. I was getting really annoyed how ugly the default icons supplied by IrfanView are, and the fact that I can't actually change it in its settings.

# Main Change
I wanted to use [this icon extension](https://imageglass.org/extension-icon/adobe-icons-set-xmha97-4) made for ImageGlass, so I revised the registry update segment to also associate file types not initially covered by IrfanView's Icons.dll (e.g. AVIF).

# Other changes
- UAC prompt elevation on script start
- Semantics, mostly on the error catch echoes

## Proof of work
<img src="https://github.com/user-attachments/assets/dea52b7e-6838-4b60-8961-b27336bdfa8a" height="360"/>
<img src="https://github.com/user-attachments/assets/90b629ac-eab7-4bc4-b722-adf90f6631ed" height="360"/>

## P.S.
The changes I'm PR'ing to `run.bat` is for diff. comparison. [This is my actual `run.bat` as `.txt`](https://github.com/user-attachments/files/21049612/run-new.txt) since I can't push new files.

`revert.bat` won't work with this change as new registry keys are made without distinction from those supplied by IrfanView's Icons.dll. There's also the off-chance that the user might accidentally associate a file IrfanView doesn't support since there's no compatibility checks. I could address these later once I find a definitive list of all the file types IrfanView can open.